### PR TITLE
Fixes errors introduced by ISSUE-22

### DIFF
--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -75,8 +75,9 @@ format_strawberryfield.metadatadisplay_caster:
         type: 'entity:node'
       metadataexposeconfig_entity:
         type: 'entity:metadataexpose_entity'
+      resource_type:
+        type: 'ado'
   requirements:
-    node: \d+
     format: .+
     _entity_access: 'node.view'
 

--- a/src/Entity/MetadataExposeConfigEntity.php
+++ b/src/Entity/MetadataExposeConfigEntity.php
@@ -237,11 +237,11 @@ class MetadataExposeConfigEntity extends ConfigEntityBase implements MetadataCon
     ConfigEntityInterface $a,
     ConfigEntityInterface $b
   ) {
-    /** @var \Drupal\Core\Entity\EntityDisplayModeInterface $a */
-    /** @var \Drupal\Core\Entity\EntityDisplayModeInterface $b */
+    /** @var \Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity $a */
+    /** @var \Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity $b */
     // Sort by the type the source Metadata Display this entity uses.
-    $a_type = $a->getProcessorEntity();
-    $b_type = $b->getProcessorEntity();
+    $a_type = $a->getLabel();
+    $b_type = $b->getLabel();
     $type_order = strnatcasecmp($a_type, $b_type);
     return $type_order != 0 ? $type_order : parent::sort($a, $b);
   }

--- a/src/Form/MetadataExposeConfigEntityDeleteForm.php
+++ b/src/Form/MetadataExposeConfigEntityDeleteForm.php
@@ -1,7 +1,7 @@
 <?php
 namespace Drupal\format_strawberryfield\Form;
 
-use Drupal\Core\Entity\ContentEntityConfirmFormBase;
+use Drupal\Core\Entity\EntityConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 
@@ -10,7 +10,7 @@ use Drupal\Core\Url;
  *
  * @ingroup format_strawberryfield
  */
-class MetadataExposeConfigEntityDeleteForm extends ContentEntityConfirmFormBase {
+class MetadataExposeConfigEntityDeleteForm extends EntityConfirmFormBase {
 
   public function getQuestion() {
     return $this->t('Are you sure you want to delete %name?', ['%name' => $this->entity->label()]);
@@ -32,10 +32,9 @@ class MetadataExposeConfigEntityDeleteForm extends ContentEntityConfirmFormBase 
     $this->entity->delete();
 
     $this->messenger()->addMessage(
-      $this->t('content @type: deleted @label.',
+      $this->t('Metadata exposed endpoint @label deleted.',
         [
-          '@type' => $this->entity->bundle(),
-          '@label' => $this->entity->label(),
+          '@label' => $this->entity->getLabel(),
         ]
       )
     );


### PR DESCRIPTION
Mostly my fault: i introduced some errors because i did this piece in too many attempts and left first attempt code around. This fixes:
- Deleting an Exposed Metadata Config Entity (Wrong class for the form)
- Better message when deleting
- Sorting by label when showing the list of entities.
- Removes the Regular expression matcher for the route and adds our new resource_type =  'ado' parameter to the actual endpoint so the https://github.com/esmero/strawberryfield/tree/ISSUE-47 can be used. Does not affect right now anything other than ID resolving versus UUID resolving