### PR TITLE
ISSUE-52: normalize IIIF Server URLs (#53)

### DIFF
--- a/src/Controller/MetadataExposeDisplayController.php
+++ b/src/Controller/MetadataExposeDisplayController.php
@@ -202,7 +202,7 @@ class MetadataExposeDisplayController extends ControllerBase {
 
           $context['iiif_server'] = $this->config(
             'format_strawberryfield.iiif_settings'
-          )->get('pub_server_url').'/';
+          )->get('pub_server_url');
           $cacheabledata = [];
           // @see https://www.drupal.org/node/2638686 to understand
           // What cacheable, Bubbleable metadata and early rendering means.

--- a/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
@@ -110,8 +110,8 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
     // @TODO maybe we want the opposite? like add the slash always?
     // Also why are we not removing on save but on fetch?
     $urls = [
-      'public' => boolval($this->getSetting('use_iiif_globals')) === TRUE ? $this->iiifConfig->get('pub_server_url') : rtrim($this->getSetting('iiif_base_url'), "/"),
-      'internal' => boolval($this->getSetting('use_iiif_globals')) === TRUE ? $this->iiifConfig->get('int_server_url') : rtrim($this->getSetting('iiif_base_url_internal'), "/"),
+      'public' => boolval($this->getSetting('use_iiif_globals')) === TRUE ?  rtrim($this->iiifConfig->get('pub_server_url'),"/") : rtrim($this->getSetting('iiif_base_url'), "/"),
+      'internal' => boolval($this->getSetting('use_iiif_globals')) === TRUE ? rtrim($this->iiifConfig->get('int_server_url'),"/") : rtrim($this->getSetting('iiif_base_url_internal'), "/"),
     ];
     return $urls;
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
@@ -284,7 +284,7 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
           '#context' => [
             'data' => $jsondata,
             'node' => $items->getEntity(),
-            'iif_server' => $this->getIiifUrls()['public'].'/',
+            'iiif_server' => $this->getIiifUrls()['public'],
           ],
         ];
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -468,7 +468,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
         $context = [
           'data' => $jsondata,
           'node' => $item->getEntity(),
-          'iiif_server' => $this->getIiifUrls()['public'].'/',
+          'iiif_server' => $this->getIiifUrls()['public'],
         ];
         $twigtemplate = $entity->get('twig')->getValue();
         $twigtemplate = !empty($twigtemplate) ? $twigtemplate[0]['value'] : "{{ field.label }}";


### PR DESCRIPTION
* Remove trailing slashes from Twig injection and fix broken Context variables

What a mess. But now we got it right. We introduced new Form/base clases for formatters 30-60 days or so ago and this got mixed up.

* For legacy reasons also strip / from already saved values