### PR TITLE
Issue-54: Finally schemas are fixed and we have linked Thumbnails (#63)

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -55,13 +55,15 @@ field.formatter.settings.strawberry_image_formatter:
       type: string
       label: 'Whether to use global IIIF settings or not.'
     number_images:
-      type: integer
-    images_type:
+      type: string
+    image_type:
       type: string
     quality:
       type: string
     rotation:
       type: string
+    image_link:
+      type: boolean
 field.formatter.settings.strawberry_media_formatter:
   type: mapping
   label: 'Specific Config for strawberry_media_formatter'

--- a/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
@@ -158,7 +158,6 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
 
     return [
       'customtext' => [
-        '#type' => 'item',
         '#markup' => '<h3>Use this form to select the template for your metadata.</h3><p>Several templates such as MODS 3.6 and a simple Object Description ship with Archipelago. To design your own template for any metadata standard you like, or see the full list of existing templates, visit <a href="/metadatadisplay/list">/metadatadisplay/list</a>. </p>',
       ],
       'metadatadisplayentity_id' => [
@@ -243,7 +242,8 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
         continue;
       }
 
-      $jsondata = json_decode($item->value, true);
+      $jsondata = json_decode($item->value, TRUE);
+
       // Probably good idea to strip our own keys here
       // @TODO remove private access to keys
 


### PR DESCRIPTION
* Fix StrawberryMetadataTwigFormatter

Settings form was using an 'item' #type wich implies a saved value in the settings. That is wrong since we needed that element only to display contextual info the user. Since i'm here also add a Link Element to the Image Formatter (around) and fix other (yes more!) wrong schema elements.

* Its '#uri 'not '#url'

* String-i-fy

* Give image_formatter a try

* That was a bad idea!

We are generating images via IIIF, we really don't want to use Drupal's entity view of files here.

* Tiny typo

* maybe nested render array works?

* Add alt?

I thought Drupal was adding this.. well no!

* No need for a type