### PR TITLE
ISSUE-64: Fix duplicated HTML id/ Mirador and Map (#65)

### DIFF
--- a/js/mirador_strawberry.js
+++ b/js/mirador_strawberry.js
@@ -12,7 +12,9 @@
                     if (typeof(drupalSettings.format_strawberryfield.mirador[element_id]) != 'undefined') {
 
                         $(this).height(drupalSettings.format_strawberryfield.mirador[element_id]['height']);
-                        $(this).width(drupalSettings.format_strawberryfield.mirador[element_id]['width']);
+                        if (drupalSettings.format_strawberryfield.mirador[element_id]['width'] != '100%') {
+                            $(this).width(drupalSettings.format_strawberryfield.mirador[element_id]['width']);
+                        }
                         // Defines our basic options for Mirador IIIF.
                         var $options = {
                             id: element_id,

--- a/src/Plugin/Field/FieldFormatter/StrawberryMapFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMapFormatter.php
@@ -599,7 +599,7 @@ class StrawberryMapFormatter extends StrawberryBaseFormatter implements Containe
         if (!empty($main_geojsonurl)) {
 
           $groupid = 'iiif-' . $item->getName(
-            ) . '-' . $nodeuuid . '-' . $delta . '-media';
+            ) . '-' . $nodeuuid . '-' . $delta . '-map';
           $htmlid = $groupid;
 
           $elements[$delta]['media'] = [

--- a/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
@@ -520,7 +520,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
       if (!empty($main_manifesturl)) {
 
         $groupid = 'iiif-' . $item->getName(
-          ) . '-' . $nodeuuid . '-' . $delta . '-media';
+          ) . '-' . $nodeuuid . '-' . $delta . '-mirador';
         $htmlid = $groupid;
 
         $elements[$delta]['media'] = [
@@ -535,7 +535,6 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
               'container',
             ],
             'style' => "width:{$max_width_css}; height:{$max_height}px",
-            'width' => $max_width,
             'height' => $max_height,
           ],
         ];


### PR DESCRIPTION
* Fix shared HTML ids

Mirador and Map were using the same ID as Media. Means openseadragon + mirador + Map would end conflicting in the JS realm.

* remove width HTML property for Mirador

* JQuery .width with an % sets a static pixel value

New to me. So if we already set a with to 100%, $(this).width() translates to pixels. and Based on full screen. So bad.