### PR TITLE
Reflect 1.0.0 rc1 and  Comment out duplicated _entity_access  (#88)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "require": {
         "ml/json-ld": "^1.2",
         "mtdowling/jmespath.php":"^2.5",
-        "strawberryfield/strawberryfield":"dev-8.x-1.0-beta3",
-        "drupal/webform": "^5.19",
+        "strawberryfield/strawberryfield":"dev-1.0.0-RC1",
+        "drupal/webform": "^5.19 || ^6.0",
         "drupal/webform_views": "^5.0"
     }
 }

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -93,7 +93,7 @@ format_strawberryfield.metadatadisplay_caster:
   requirements:
     format: .+
     _entity_access: 'node.view'
-    _entity_access: 'metadataexpose_entity.view'
+#    _entity_access: 'metadataexpose_entity.view'
 
 format_strawberryfield.iiif_admin_settings_form:
   path: '/admin/config/archipelago/iiif'


### PR DESCRIPTION
* Comment out duplicated _entity_access
* Adds Webform 6.0 as composer.json requirement (with an OR) for Drupal 9 Compatibility