### PR TITLE
Addresses #94 Twig deprecation

### DIFF
--- a/src/Entity/MetadataDisplayEntity.php
+++ b/src/Entity/MetadataDisplayEntity.php
@@ -271,7 +271,7 @@ class MetadataDisplayEntity extends ContentEntityBase implements MetadataDisplay
       ->setDisplayConfigurable('view', TRUE)
       ->setRequired(TRUE)
       ->addConstraint('NotBlank')
-      ->addConstraint('TwigTemplateConstraint', ['useTwigMessage' => FALSE]);
+      ->addConstraint('TwigTemplateConstraint', ['useTwigMessage' => FALSE, 'TwigTemplateLogicalName' => 'MetadataDisplayEntity']);
 
     // Owner field of the Metadata Display Entity.
     // Entity reference field, holds the reference to the user object.

--- a/src/Plugin/Validation/Constraint/TwigTemplateConstraint.php
+++ b/src/Plugin/Validation/Constraint/TwigTemplateConstraint.php
@@ -21,4 +21,5 @@ use Symfony\Component\Validator\Constraint;
 class TwigTemplateConstraint extends Constraint{
   public $message = 'Value is not a valid Twig template.';
   public $useTwigMessage = false;
+  public $TwigTemplateLogicalName = 'MetadataDisplayEntity';
 }

--- a/src/Plugin/Validation/Constraint/TwigTemplateConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/TwigTemplateConstraintValidator.php
@@ -13,6 +13,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Template\TwigEnvironment;
+use Twig\Source;
 use Twig_Error_Syntax;
 
 
@@ -44,7 +45,8 @@ class TwigTemplateConstraintValidator extends ConstraintValidator implements Con
     $twig = $this->twig;
     $message = $constraint->message;
     try {
-      $twig->parse($twig->tokenize($value->value));
+      $source = new Source($value->value, $constraint->TwigTemplateLogicalName);
+      $twig->parse($twig->tokenize($source));
     } catch (Twig_Error_Syntax $e) {
       if ($constraint->useTwigMessage) {
         $message = $e->getMessage();


### PR DESCRIPTION
This fixes the Twig 2.0 deprecation under Drupal 9 descibed in #94
Pro tip: do a general search inside the  `web/vendor` folder for "deprecated" if you want to cry on a monday!

@alliomeria @giancarlobi